### PR TITLE
eks: fix cluster access (main.tf) by enabling IRSA + API_AND_CONFIG_M…

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,97 +1,59 @@
-# Terraform Exercise — VPC & EKS Setup (main.tf only)
+# 🚀 Terraform — VPC & EKS Setup
 
-A minimal Terraform configuration that provisions a **VPC** and an **Amazon EKS cluster** using public modules.  
-This exercise focuses on declaring providers, consuming modules, and passing inputs.
+Minimal **Terraform configuration** that provisions:
+- A **VPC** with public + private subnets  
+- An **EKS cluster** (v1.29) with one managed node group  
+- IAM → RBAC mapping using **EKS access entries**
 
 ---
 
 ## ✅ What this creates
-
 ### Networking (VPC Module)
-- **AWS region:** `us-east-1`  
-- **VPC CIDR:** `10.0.0.0/16`  
-- **Availability Zones:** `us-east-1a`, `us-east-1b`  
-- **Subnets:**  
-  - 2 × **private** — `10.0.1.0/24`, `10.0.2.0/24`  
-  - 2 × **public** — `10.0.3.0/24`, `10.0.4.0/24`  
-- **Internet access:** single **NAT Gateway** for private subnets  
+- Region: `us-east-1`
+- CIDR: `10.0.0.0/16`
+- 2 × private subnets (`10.0.1.0/24`, `10.0.2.0/24`)
+- 2 × public subnets (`10.0.3.0/24`, `10.0.4.0/24`)
+- Single **NAT Gateway** for private subnets
 
 ### Kubernetes (EKS Module)
-- **EKS Cluster:** named `myEKS-cluster`  
-- **Cluster version:** defined in `terraform.tfvars`  
-- **Managed Node Group:**  
-  - At least 1 node (t3.medium by default, configurable)  
-  - Nodes spread across the private subnets  
-- **IAM roles & security groups** required for cluster and nodes  
-
-> ℹ️ This repo intentionally uses a single file: **`main.tf`**, plus variable values in `terraform.tfvars`.
+- Cluster name: `myEKS-cluster`  
+- Version: `1.29` (configurable)  
+- Managed node group: `t3.small` spot instance  
+- `enable_irsa = true` → IAM Roles for Service Accounts  
+- `authentication_mode = "API_AND_CONFIG_MAP"` → allows both ConfigMap + API-based access  
+- `access_entries` → maps IAM user/role (e.g. `dan_user`) to Kubernetes admin
 
 ---
 
-## 💡 Learning goals
+## ▶️ Usage
 
-- Declare and configure the **AWS provider**  
-- Use Terraform Registry modules:  
-  - **VPC module** for networking  
-  - **EKS module** for Kubernetes cluster  
-- Pass inputs like subnets, AZs, cluster name, and tags  
-- Launch a managed **EKS Node Group** inside the VPC  
-
----
-
-## 🧰 Prerequisites
-
-- Terraform `>= 1.5`  
-- AWS account with permissions for VPC, IAM, and EKS  
-- Credentials configured via one of:  
-  - `aws configure` (AWS CLI), or  
-  - environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION=us-east-1`)  
-
----
-
-## ▶️ How to run
-
-From the folder containing `main.tf`:
+Initialize & apply:
 
 ```bash
-terraform init          # Download providers and modules
-terraform validate      # (optional) Static checks
-terraform plan          # (optional) Preview resources
-terraform apply         # Create VPC + EKS + Node Group
+terraform init
+terraform apply
 ```
 
-Once apply completes, update your kubeconfig:
+Update kubeconfig:
 
 ```bash
 aws eks update-kubeconfig --region us-east-1 --name myEKS-cluster
-kubectl get nodes        # Verify the worker nodes are ready
+kubectl get nodes
 ```
+
+---
+
+## 🧰 Files
+
+- **main.tf** — provider, VPC, EKS (with IRSA + access entries)  
+- **variables.tf** — region, cluster_name  
+- **terraform.tfvars** — values (`us-east-1`, `myEKS-cluster`)  
 
 ---
 
 ## 🧹 Clean up
-
-Destroy all resources when you’re done:
-
 ```bash
 terraform destroy
 ```
-
-This will delete the VPC, the EKS cluster, and the managed node group.  
-
----
-
-## 💸 Cost notice
-
-Running an **EKS cluster** with worker nodes and a NAT Gateway incurs hourly charges.  
-Use `terraform destroy` after the exercise to avoid unnecessary costs.
-
----
-
-## 🧭 Key elements in `main.tf`
-
-- **`provider "aws"`** block for region setup  
-- **`module "vpc"`** for network infrastructure  
-- **`module "eks"`** for Kubernetes control plane & nodes  
-- **`terraform.tfvars`** provides region, cluster name, and other inputs  
-
+Deletes VPC, EKS cluster, and node group.  
+⚠️ Reminder: **EKS + NAT Gateway incur hourly cost**.


### PR DESCRIPTION
…AP and mapping IAM user via access_entries; update README

Without these settings, new clusters block kubectl access (forbidden). Now the IAM user (dan_user) is mapped as cluster-admin during creation, so kubeconfig works right after apply.

The README was updated to reflect these changes for beginners.