### PR TITLE
k8s: turn off Flask DEBUG via deploy/flask-configmap.yaml

### DIFF
--- a/deploy/flask-configmap.yaml
+++ b/deploy/flask-configmap.yaml
@@ -4,5 +4,5 @@ metadata:
   name: flask-config
 data:
   PORT: "5000"
-  DEBUG: "true"
+  DEBUG: "false"
   DB_HOST: "localhost"


### PR DESCRIPTION
Summary
- Disable Flask debug mode for production on EKS.

What changed
- Edited deploy/flask-configmap.yaml: set DEBUG: "false".

Why
- Flask debug can expose stack traces and sensitive info.
- Not needed in production; safer and slightly leaner

Rollback
- Revert to DEBUG: "true" and repeat rollout if needed