### PR TITLE
Split CI/CD workflows; replace legacy developer.yaml files

### DIFF
--- a/.github/workflows/cd-main.yaml
+++ b/.github/workflows/cd-main.yaml
@@ -1,24 +1,9 @@
-# .github/workflows/developer.yaml
-name: Tasks API CI/CD
 
+name: Task CD (Main Deploy)
 on:
-  workflow_dispatch:          # Allows manual trigger of the workflow from GitHub Actions UI
-    inputs:
-      deploy:                 # Input parameter that appears in the "Run workflow" dialog
-        description: "Push image to DockerHub?"   # Text shown in the UI to explain what this input does
-        required: true        # The user must provide a value (true/false) before running
-        type: boolean         # Defines the input as a boolean toggle (true/false)
-        default: false        # Default value is 'false' (so manual runs will not deploy unless explicitly chosen)
-        
   push:
     branches:
-      - 'feature-*'   # Run workflow on pushes to any feature branch (CI)
-      - 'refactor-*' # Run workflow on pushes to any refactor branch (CI)
-      - 'main'        # Run workflow on pushes to main (after merge, for CD)
-      - 'build-*'
-  pull_request:
-    branches:
-      - main          # Run workflow on pull requests targeting main (PR checks)
+      - 'main'
 
 jobs:
   build-and-test:
@@ -45,7 +30,7 @@ jobs:
 
     - name: Test API Endpoints
       run: |
-        # Test the GET /tasks endpoint to ensure it responds successfully (2xx)
+        # Test the GET /tasks endpoint to ensure it responds successfully 
         echo "Testing GET /tasks..."
         curl -f http://localhost:5000/tasks
 
@@ -66,7 +51,9 @@ jobs:
           curl -f http://localhost:5000/tasks/$TASK_ID
 
           echo "Testing PUT /tasks/$TASK_ID (update specific task)..."
-          curl -f -X PUT -H "Content-Type: application/json" -d "{\"name\":\"${TASK_NAME}\"}" http://localhost:5000/tasks/$TASK_ID
+          TASK_NAME="Updated Task Name"
+          TASK_AUTHOR="CI Bot" 
+          curl -f -X PUT -H "Content-Type: application/json" -d "{\"name\":\"${TASK_NAME}\", \"author\":\"${TASK_AUTHOR}\"}" http://localhost:5000/tasks/$TASK_ID
 
           echo "Testing DELETE /tasks/$TASK_ID (delete specific task)..."
           curl -f -X DELETE http://localhost:5000/tasks/$TASK_ID
@@ -85,18 +72,18 @@ jobs:
     
     # Login step (only on push to main)
     - name: Login to Docker Hub
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_LOGIN_RUN }}
         password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
     - name: Push image (commit SHA)
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       run: docker push codeislife771/flask-task-manager:${{ github.sha }}
 
     - name: Tag & push latest
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       run: |
         docker tag codeislife771/flask-task-manager:${{ github.sha }} codeislife771/flask-task-manager:latest
         docker push codeislife771/flask-task-manager:latest

--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -1,0 +1,89 @@
+name: Tasks CI (Dev/Feature)
+
+on:
+  push:
+    branches:
+      - 'feature-*'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Build Docker image
+      run: docker build -t codeislife771/flask-task-manager:${{ github.sha }} .
+    
+    - name: Start API container
+      run: |
+        docker run -d \
+          --name tasks-container \
+          -p 5000:5000 \
+          codeislife771/flask-task-manager:${{ github.sha }}
+        
+        # Wait for API to be ready (adjust port if different)
+        echo "Waiting for API to be ready..."
+        timeout 60 bash -c 'until curl -f http://localhost:5000/health; do echo "Waiting..."; sleep 2; done'
+        echo "API is ready!"
+
+    - name: Test API Endpoints
+      run: |
+        # Test the GET /tasks endpoint to ensure it responds successfully 
+        echo "Testing GET /tasks..."
+        curl -f http://localhost:5000/tasks
+
+        echo "Testing POST /tasks (create new task)..."
+        CREATE_RESPONSE=$(curl -s -X POST \
+          -H "Content-Type: application/json" \
+          -d '{"name":"Test Task","author":"Test Author"}' \
+          http://localhost:5000/tasks)
+
+        # Print the HTTP status code received
+        echo "POST /tasks -> HTTP $CREATE_RESPONSE"
+
+        # Extract task ID from the response for further testing (assuming JSON response has id field)
+        TASK_ID=$(echo $CREATE_RESPONSE | jq -r '.id // .uuid // empty')
+        
+        if [ ! -z "$TASK_ID" ]; then
+          echo "Testing GET /tasks/$TASK_ID (get specific task)..."
+          curl -f http://localhost:5000/tasks/$TASK_ID
+
+          echo "Testing PUT /tasks/$TASK_ID (update specific task)..."
+          TASK_NAME="Updated Task Name"
+          TASK_AUTHOR="CI Bot" 
+          curl -f -X PUT -H "Content-Type: application/json" -d "{\"name\":\"${TASK_NAME}\", \"author\":\"${TASK_AUTHOR}\"}" http://localhost:5000/tasks/$TASK_ID
+
+          echo "Testing DELETE /tasks/$TASK_ID (delete specific task)..."
+          curl -f -X DELETE http://localhost:5000/tasks/$TASK_ID
+        fi
+
+    
+    - name: Show container logs (for debugging)
+      if: failure()
+      run: docker logs tasks-container
+    
+    - name: Stop and cleanup containers
+      if: always()
+      run: |
+        docker stop tasks-container || true
+        docker rm tasks-container || true
+    
+    # Login step (only on push to main)
+    - name: Login to Docker Hub
+      if: github.ref == 'refs/heads/main'
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_LOGIN_RUN }}
+        password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+    - name: Push image (commit SHA)
+      if: github.ref == 'refs/heads/main'
+      run: docker push codeislife771/flask-task-manager:${{ github.sha }}
+
+    - name: Tag & push latest
+      if: github.ref == 'refs/heads/main'
+      run: |
+        docker tag codeislife771/flask-task-manager:${{ github.sha }} codeislife771/flask-task-manager:latest
+        docker push codeislife771/flask-task-manager:latest


### PR DESCRIPTION
- Add ci-dev.yaml for feature branches CI.
- Add cd-main.yaml for main branch CD (build+test+push).
- Remove legacy developer.yaml to prevent duplicate runs.
- Fix PUT test: include TASK_NAME and TASK_AUTHOR so required fields are sent.