### PR TITLE
ci: run unit tests on Actions runner before Docker build

### DIFF
--- a/.github/workflows/cd-main.yaml
+++ b/.github/workflows/cd-main.yaml
@@ -12,6 +12,12 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
+    - name: Run unit tests
+      run: python3 -m unittest test_tasks.py
     
     - name: Build Docker image
       run: docker build -t codeislife771/flask-task-manager:${{ github.sha }} .

--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -12,6 +12,12 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
+    - name: Run unit tests
+      run: python3 -m unittest test_tasks.py
     
     - name: Build Docker image
       run: docker build -t codeislife771/flask-task-manager:${{ github.sha }} .


### PR DESCRIPTION
 - Run unit tests on the GitHub Actions runner (outside the container) for quicker feedback.
 - Add CI steps to ci-dev.yaml and cd-main.yaml:
 - Set up Python, pip install -r requirements.txt, then python3 -m unittest -v test_tasks.py.
 - Use fail-fast: run tests before any Docker build/run.
 - Keep integration tests containerized (curl against the API) for production-like validation.