### PR TITLE
Fix GitHub Actions workflow: use vars.AWS_REGION instead of var.AWS_REGION

### DIFF
--- a/.github/workflows/infra.yaml
+++ b/.github/workflows/infra.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           aws-access-key-id:     ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region:            ${{ secrets.AWS_REGION }}
+          aws-region:            ${{ vars.AWS_REGION }}
 
       - uses: hashicorp/setup-terraform@v3
 


### PR DESCRIPTION
- AWS region is defined as a GitHub Variable (not a Secret)
- Correct context in workflows is 'vars.AWS_REGION'
- This fix ensures AWS credentials are configured properly
