### PR TITLE
Update Terraform workflow: add -auto-approve flag to plan step

### DIFF
--- a/.github/workflows/infra.yaml
+++ b/.github/workflows/infra.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: terraform plan
         if: inputs.action == 'plan'
-        run: terraform plan
+        run: terraform plan -auto-approve # Run without waiting for manual 'yes' approval in GitHub Actions
 
       - name: terraform apply
         if: inputs.action == 'apply'


### PR DESCRIPTION
Ensures workflow does not wait for manual input during 'terraform plan', so it runs automatically in GitHub Actions.