### PR TITLE
Fix Terraform workflow: remove -auto-approve from plan (not needed) and add it to apply to run non-interactively

### DIFF
--- a/.github/workflows/infra.yaml
+++ b/.github/workflows/infra.yaml
@@ -33,11 +33,11 @@ jobs:
 
       - name: terraform plan
         if: inputs.action == 'plan'
-        run: terraform plan -auto-approve # Run without waiting for manual 'yes' approval in GitHub Actions
+        run: terraform plan 
 
       - name: terraform apply
         if: inputs.action == 'apply'
-        run: terraform apply
+        run: terraform apply -auto-approve # Run without waiting for manual 'yes' approval in GitHub Actions
 
       - name: terraform destroy
         if: inputs.action == 'destroy'


### PR DESCRIPTION
Fix Terraform workflow: remove -auto-approve from plan (not needed) and add it to apply to run non-interactively