### PR TITLE
ci: build & push Docker image by commit SHA (removed latest, renamed cd-main.yaml to cd-deploy.yaml)

### DIFF
--- a/.github/workflows/cd-deploy.yaml
+++ b/.github/workflows/cd-deploy.yaml
@@ -1,0 +1,25 @@
+name: Task CD (Main Deploy)
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Docker login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_LOGIN_RUN }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Build Docker image (by SHA)
+        run: docker build -t codeislife771/flask-task-manager:${{ github.sha }} .
+
+      - name: Push image (by SHA)
+        run: docker push codeislife771/flask-task-manager:${{ github.sha }}


### PR DESCRIPTION
- Workflow file renamed from cd-main.yaml to cd-deploy.yaml
- Build Docker image tagged with commit SHA instead of using 'latest'
- Removed the step that tagged & pushed the 'latest' image
