### PR TITLE
ci(infra): fix infra workflow to run kubectl from repo root and adjust tfstate paths

### DIFF
--- a/.github/workflows/infra.yaml
+++ b/.github/workflows/infra.yaml
@@ -1,26 +1,9 @@
-name: Infra (Plan/Apply/Destroy)
-
-on:
-  workflow_dispatch:
-    inputs:
-      action:
-        type: choice
-        options: [plan, apply, destroy]
-        default: plan
-      dir:
-        default: terraform
-
 jobs:
   tf:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.dir }}
-
     steps:
       - uses: actions/checkout@v4
 
-      # Configure AWS credentials for the job
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id:     ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -29,25 +12,21 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v3
 
-      # Always try to restore tfstate at the start (plan/apply/destroy).
-      # If no artifact exists yet (first run), don't fail the job.
       - name: Restore tfstate (all actions)
         uses: actions/download-artifact@v4
         with:
           name: tfstate
-          path: ${{ inputs.dir }}
+          path: terraform
         continue-on-error: true
 
-      # --- Simple Kubernetes cleanup before Terraform destroy ---
-      # Optional cleanup before destroy: remove K8s resources that may hold AWS LBs/ENIs
+      # --- K8s cleanup (destroy only) ---
       - name: Install kubectl (only for destroy)
         if: inputs.action == 'destroy'
         uses: azure/setup-kubectl@v4
 
       - name: Connect kubectl to EKS (only for destroy)
         if: inputs.action == 'destroy'
-        run: |
-          aws eks update-kubeconfig --name "${{ vars.EKS_CLUSTER_NAME }}" --region "${{ vars.AWS_REGION }}"
+        run: aws eks update-kubeconfig --name "${{ vars.EKS_CLUSTER_NAME }}" --region "${{ vars.AWS_REGION }}"
 
       - name: Undeploy app (only for destroy)
         if: inputs.action == 'destroy'
@@ -56,32 +35,35 @@ jobs:
           sleep 20
           kubectl delete -f deploy/ --ignore-not-found
           kubectl get svc -A | (grep LoadBalancer || true)
-      # --- end of Kubernetes cleanup ---
+      # --- end K8s cleanup ---
 
-      # Terraform workflow
+      # Terraform steps (run inside terraform/)
       - name: terraform init
+        working-directory: terraform
         run: terraform init -input=false
 
       - name: terraform plan
         if: inputs.action == 'plan'
+        working-directory: terraform
         run: terraform plan -input=false
 
       - name: terraform apply
         if: inputs.action == 'apply'
+        working-directory: terraform
         run: terraform apply -auto-approve -input=false
 
       - name: terraform destroy
         if: inputs.action == 'destroy'
+        working-directory: terraform
         run: terraform destroy -auto-approve -input=false
 
-      # Always save tfstate at the end (even on failure) so next run has continuity.
       - name: Save tfstate (always)
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: tfstate
           path: |
-            ${{ inputs.dir }}/terraform.tfstate
-            ${{ inputs.dir }}/terraform.tfstate.backup
+            terraform/terraform.tfstate
+            terraform/terraform.tfstate.backup
           if-no-files-found: ignore
           retention-days: 14


### PR DESCRIPTION
Fix infra workflow (.github/workflows/infra.yaml):

- Remove global defaults.run.working-directory
- Run kubectl cleanup from repo root (deploy/ exists)
- Keep Terraform steps with working-directory=terraform
- Adjust tfstate restore/save paths

This fixes errors during `destroy` (kubectl couldn't find deploy/).