### PR TITLE
ci(infra): restore workflow_dispatch for manual plan/apply/destroy runs

### DIFF
--- a/.github/workflows/infra.yaml
+++ b/.github/workflows/infra.yaml
@@ -1,23 +1,49 @@
+name: Infra (Plan/Apply/Destroy)
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: What to run
+        required: true
+        type: choice
+        options: [plan, apply, destroy]
+        default: plan
+      dir:
+        description: Terraform working directory
+        required: false
+        default: terraform
+
 jobs:
   tf:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
 
-      - uses: aws-actions/configure-aws-credentials@v4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id:     ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region:            ${{ vars.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v3
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
 
+      # Always try to restore previous state (plan/apply/destroy). If none exists, don't fail.
       - name: Restore tfstate (all actions)
         uses: actions/download-artifact@v4
         with:
           name: tfstate
           path: terraform
         continue-on-error: true
+
+      # Optional sanity — helps ensure state is loaded before destroy
+      - name: Sanity: terraform state list
+        working-directory: terraform
+        run: terraform state list || true
 
       # --- K8s cleanup (destroy only) ---
       - name: Install kubectl (only for destroy)
@@ -26,15 +52,24 @@ jobs:
 
       - name: Connect kubectl to EKS (only for destroy)
         if: inputs.action == 'destroy'
-        run: aws eks update-kubeconfig --name "${{ vars.EKS_CLUSTER_NAME }}" --region "${{ vars.AWS_REGION }}"
+        run: |
+          set -e
+          aws eks update-kubeconfig --name "${{ vars.EKS_CLUSTER_NAME }}" --region "${{ vars.AWS_REGION }}"
 
       - name: Undeploy app (only for destroy)
         if: inputs.action == 'destroy'
         run: |
+          # If the cluster/context does not exist, skip gracefully
+          set +e
           kubectl delete service flask-service --ignore-not-found
-          sleep 20
-          kubectl delete -f deploy/ --ignore-not-found
-          kubectl get svc -A | (grep LoadBalancer || true)
+          sleep 15
+          if [ -d "deploy" ]; then
+            kubectl delete -f deploy/ --ignore-not-found
+          else
+            echo "deploy/ not found at repo root; skipping kubectl delete -f deploy/"
+          fi
+          kubectl get svc -A 2>/dev/null | (grep LoadBalancer || true)
+          set -e
       # --- end K8s cleanup ---
 
       # Terraform steps (run inside terraform/)
@@ -57,6 +92,7 @@ jobs:
         working-directory: terraform
         run: terraform destroy -auto-approve -input=false
 
+      # Always save tfstate at the end so the next run has continuity
       - name: Save tfstate (always)
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Re-added `workflow_dispatch` with inputs (plan/apply/destroy, dir)
- Enables manual runs from GitHub Actions UI
- Complements previous infra workflow fixes