### PR TITLE
ci(infra): remove sanity step (terraform state list)

### DIFF
--- a/.github/workflows/infra.yaml
+++ b/.github/workflows/infra.yaml
@@ -43,11 +43,6 @@ jobs:
           path: ${{ github.event.inputs.dir }}
         continue-on-error: true
 
-      # Optional sanity — helps ensure state is loaded before destroy
-      - name: "Sanity: terraform state list"
-        working-directory: ${{ github.event.inputs.dir }}
-        run: terraform state list || truegit 
-
       # --- K8s cleanup (destroy only) ---
       - name: Install kubectl (only for destroy)
         if: ${{ github.event.inputs.action == 'destroy' }}


### PR DESCRIPTION
- Removed the optional "terraform state list" step.
- The step was only for debugging but caused failures/noise when no tfstate existed.
- Simplifies infra workflow while keeping plan/apply/destroy functional.
