### PR TITLE
fix: correct infra.yaml restore_fallback step (syntax compliance)

### DIFF
--- a/.github/workflows/infra.yaml
+++ b/.github/workflows/infra.yaml
@@ -41,6 +41,7 @@ jobs:
       # IMPORTANT: The 'workflow' value must be the exact path to this file.
       - name: Restore tfstate (from previous run)
         id: restore_from_previous_run
+        continue-on-error: true
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: .github/workflows/infra.yaml   # exact workflow file path
@@ -48,13 +49,13 @@ jobs:
           branch: main                             # change if your artifact was produced on a different branch
           path: ${{ github.event.inputs.dir }}     # extract into the TF working dir (e.g., terraform/)
           if_no_artifact_found: warn
-        continue-on-error: true
 
       # Optional fallback: try to fetch the latest successful artifact on the branch,
       # even if it's from a different workflow file (useful if the exact file changed).
       - name: Restore tfstate (fallback: latest successful on branch)
         id: restore_fallback
         if: ${{ (steps.restore_from_previous_run.outcome == 'failure') || (steps.restore_from_previous_run.outcome == 'cancelled') || (steps.restore_from_previous_run.outcome == 'skipped') }}
+        continue-on-error: true
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow_conclusion: success
@@ -62,8 +63,6 @@ jobs:
           branch: main
           path: ${{ github.event.inputs.dir }}
           if_no_artifact_found: warn
-        continue-on-error: true
-
 
       # Quick check to confirm whether terraform.tfstate is present before init/destroy
       - name: Verify tfstate presence


### PR DESCRIPTION
This PR fixes the YAML syntax in infra.yaml by reordering the keys in the
restore_fallback step (id, if, continue-on-error before uses/with).
This should resolve the workflow syntax error.
